### PR TITLE
Fixed failing spec on create method

### DIFF
--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -67,7 +67,7 @@ describe NanoStore::Model do
       user = User.create(:name => name, :age => age, :created_at => created_at)
       user.name.should == name
       user.age.should == age
-      user.created_at.should == created_at
+      user.created_at.to_s.should == created_at.to_s
     end
   end
 


### PR DESCRIPTION
I got a failing spec on create method:

::create
- create object with hash
  2013-09-08 10:45:34 +0530
  [✗] This test has not passed: FAILED - 2013-09-08 10:45:34 +0530.==(2013-09-08 10:45:34 +0530) failed! 
  [FAILED - 2013-09-08 10:45:34 +0530.==(2013-09-08 10:45:34 +0530) failed] 
  BACKTRACE: Bacon::Error: 2013-09-08 10:45:34 +0530.==(2013-09-08 10:45:34 +0530) failed
    spec.rb:690:in `satisfy:': ::create - create object with hash
    spec.rb:704:in`method_missing:'
    spec.rb:315:in `block in run_spec_block'
    spec.rb:439:in`execute_block'
    spec.rb:315:in `run_spec_block'
    spec.rb:330:in`run'

Added a fix to the spec, basically time objects comparison leads to failures, so converted that into string.
